### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,23 +11,23 @@ ArduinoTapTempo	KEYWORD1
 #######################################
 # Methods and Functions 
 #######################################
-onBeat KEYWORD2
-isChainActive KEYWORD2
-isChainActive KEYWORD2
-getBPM KEYWORD2
-beatProgress KEYWORD2
-resetTapChain KEYWORD2
-resetTapChain KEYWORD2
-getBeatLength KEYWORD2
-getLastTapTime KEYWORD2
-update KEYWORD2
-enableSkippedTapDetection KEYWORD2
-disableSkippedTapDetection KEYWORD2
-setSkippedTapThresholdLow KEYWORD2
-setSkippedTapThresholdHigh KEYWORD2
-setBeatsUntilChainReset KEYWORD2
-setTotalTapValues KEYWORD2
-setMaxBeatLengthMS KEYWORD2
-setMinBeatLengthMS KEYWORD2
-setMaxBPM KEYWORD2
-setMinBPM KEYWORD2
+onBeat	KEYWORD2
+isChainActive	KEYWORD2
+isChainActive	KEYWORD2
+getBPM	KEYWORD2
+beatProgress	KEYWORD2
+resetTapChain	KEYWORD2
+resetTapChain	KEYWORD2
+getBeatLength	KEYWORD2
+getLastTapTime	KEYWORD2
+update	KEYWORD2
+enableSkippedTapDetection	KEYWORD2
+disableSkippedTapDetection	KEYWORD2
+setSkippedTapThresholdLow	KEYWORD2
+setSkippedTapThresholdHigh	KEYWORD2
+setBeatsUntilChainReset	KEYWORD2
+setTotalTapValues	KEYWORD2
+setMaxBeatLengthMS	KEYWORD2
+setMinBeatLengthMS	KEYWORD2
+setMaxBPM	KEYWORD2
+setMinBPM	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords